### PR TITLE
README: de-localise AMO URL, other suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # External Application Launcher
-Communicate with external applications of your OS through a toolbar button or context menu item.
+Use external applications through a toolbar button or context menu item.
 
-"External Application Launcher" extension allows you to define customizable toolbar button and context menu items that can execute external executables by passing command-line arguments of your choice. Using this application, for instance, you can send the current page to another browser or send selected text to a text editor. It is even possible to directly send image URLs to a photo editor of your choice or send download links to an external download manager!
+This extension allows you to define a customizable toolbar button, and context menu items, to run executables by passing command-line arguments of your choice. You can, for example: 
+
+- send the current page to another browser
+- send selected text to a text editor
+- send image URLs to a photo editor
+- send download links to an external download manager!
 
 ### YouTube Preview
 [![Preview](https://img.youtube.com/vi/sTOHWbX7dKU/0.jpg)](https://www.youtube.com/watch?v=sTOHWbX7dKU)
 
 ### Links
   * Homepage: https://webextension.org/listing/external-application-button.html
-  * Chrome Store: https://chrome.google.com/webstore/detail/external-application-butt/bifmfjgpgndemajpeeoiopbeilbaifdo
-  * Firefox add-ons: https://addons.mozilla.org/en-US/firefox/addon/external-application/
-  * Opera addons: https://addons.opera.com/en/extensions/details/external-application-button/
+  * Chrome Store: [External Application Launcher](https://chrome.google.com/webstore/detail/external-application-butt/bifmfjgpgndemajpeeoiopbeilbaifdo)
+  * Firefox add-ons: [External Application Button](https://addons.mozilla.org/addon/external-application/)
+  * Opera addons: [External Application Button]https://addons.opera.com/en/extensions/details/external-application-button/)


### PR DESCRIPTION
De-localised:

https://addons.mozilla.org/addon/external-application/

Whilst here, a few other suggestions. In particular: where the
extension is listed as 'External Application Button', name the link to
match the listing.